### PR TITLE
Focus timer continued

### DIFF
--- a/assets/js/activity-display.js
+++ b/assets/js/activity-display.js
@@ -9,8 +9,7 @@ $("#startPomodoroTimer").on("click", function(evt){
   var pomodoroInterval;
 
   if (workMinutes >= 60) {
-    duration = moment.duration(workMinutes, 'minutes').asHours();
-    duration = moment.duration(duration, 'hours');
+    hourPomodoro();
   }
 
   pomodoroInterval = setInterval(function(){
@@ -19,13 +18,25 @@ $("#startPomodoroTimer").on("click", function(evt){
         clearInterval(pomodoroInterval);
         // timeDisplay.innerHTML = "Time's up!";
       } else {
-        var hours = duration.hours();
+        
         var minutes = duration.minutes();
         var seconds = duration.seconds();
-        timeDisplay.text((hours < 10 ? '0' + hours : hours) + ':' + (minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
+        timeDisplay.text((minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
       }
   }, interval);
+
+  function hourPomodoro(){
+      duration = moment.duration(workMinutes, 'minutes').asHours();
+      duration = moment.duration(duration, 'hours');
+      var hours = duration.hours();
+      var minutes = duration.minutes();
+      var seconds = duration.seconds();
+      timeDisplay.text((hours < 10 ? '0' + hours : hours) + ':' + (minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
+  }
+
 });
+
+
 
 
 

--- a/assets/js/activity-display.js
+++ b/assets/js/activity-display.js
@@ -15,12 +15,13 @@ $("#startPomodoroTimer").on("click", function(evt){
   if (workMinutes >= 60) {
     hourPomodoro();
   }
-//timer interval function
+//timer interval function for the work block
+
   pomodoroInterval = setInterval(function(){
     workDuration = moment.duration(workDuration.asMilliseconds() - interval, 'milliseconds');
-      if (duration.asMilliseconds() < 0) {
+      if (workDuration.asMilliseconds() < 0) {
         clearInterval(pomodoroInterval);
-        // timeDisplay.innerHTML = "Time's up!";
+        shortBreakStart();
       } else {
         var minutes = workDuration.minutes();
         var seconds = workDuration.seconds();
@@ -35,6 +36,35 @@ $("#startPomodoroTimer").on("click", function(evt){
       var minutes = workDuration.minutes();
       var seconds = workDuration.seconds();
       timeDisplay.text((hours < 10 ? '0' + hours : hours) + ':' + (minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
+  }
+
+  function shortBreakStart(){
+    shortBreakInterval = setInterval(function(){
+      shortBreakDuration = moment.duration(shortBreakDuration.asMilliseconds() - interval, 'milliseconds');
+        if (shortBreakDuration.asMilliseconds() < 0) {
+          clearInterval(shortBreakInterval);
+          // FUNCTION TO START RUNNING MAIN POMODORO TIMER AGAIN IF IT HAS RUN LESS THAN 4 TIMES
+          longBreakStart();//placeholder function call for testing purposes
+        } else {
+          var minutes = shortBreakDuration.minutes();
+          var seconds = shortBreakDuration.seconds();
+          timeDisplay.text((minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
+        }
+    }, interval);
+  }
+
+  function longBreakStart(){
+    longBreakInterval = setInterval(function(){
+      longBreakDuration = moment.duration(longBreakDuration.asMilliseconds() - interval, 'milliseconds');
+        if (longBreakDuration.asMilliseconds() < 0) {
+          clearInterval(longBreakInterval);
+          // FUNCTION TO START RUNNING MAIN POMODORO TIMER AGAIN FROM THE BEGINNING
+        } else {
+          var minutes = longBreakDuration.minutes();
+          var seconds = longBreakDuration.seconds();
+          timeDisplay.text((minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
+        }
+    }, interval);
   }
 });
 

--- a/assets/js/activity-display.js
+++ b/assets/js/activity-display.js
@@ -2,59 +2,47 @@
 //code block to run timer
 $("#startPomodoroTimer").on("click", function(evt){
   evt.preventDefault();
-  var workMinutes = parseInt($("#pomodoroTimer").val())
+  var workMinutes = parseInt($("#pomodoroTimer").val());
+  var shortBreak = parseInt($("#shortBreak").val());
+  var longBreak = parseInt($("#longBreak").val());
   var timeDisplay = $("#countdownTimer");
-  var duration = moment.duration(workMinutes, 'minutes');
+  var workDuration = moment.duration(workMinutes, 'minutes');
+  var shortBreakDuration = moment.duration(shortBreak, 'minutes');
+  var longBreakDuration = moment.duration(longBreak, 'minutes');
   var interval = 1000;
   var pomodoroInterval;
-
+//a condition to display time in HH:MM:SS format if user enters a value over 60 minutes
   if (workMinutes >= 60) {
     hourPomodoro();
   }
-
+//timer interval function
   pomodoroInterval = setInterval(function(){
-    duration = moment.duration(duration.asMilliseconds() - interval, 'milliseconds');
+    workDuration = moment.duration(workDuration.asMilliseconds() - interval, 'milliseconds');
       if (duration.asMilliseconds() < 0) {
         clearInterval(pomodoroInterval);
         // timeDisplay.innerHTML = "Time's up!";
       } else {
-        
-        var minutes = duration.minutes();
-        var seconds = duration.seconds();
+        var minutes = workDuration.minutes();
+        var seconds = workDuration.seconds();
         timeDisplay.text((minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
       }
   }, interval);
 
   function hourPomodoro(){
       duration = moment.duration(workMinutes, 'minutes').asHours();
-      duration = moment.duration(duration, 'hours');
-      var hours = duration.hours();
-      var minutes = duration.minutes();
-      var seconds = duration.seconds();
+      duration = moment.duration(workDuration, 'hours');
+      var hours = workDuration.hours();
+      var minutes = workDuration.minutes();
+      var seconds = workDuration.seconds();
       timeDisplay.text((hours < 10 ? '0' + hours : hours) + ':' + (minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
   }
-
 });
 
 
 
 
 
-// var pomodoroInterval;
-// $("#startPomodoroTimer").on("click", function(evt){
-//   evt.preventDefault();
-//   console.log(startTime.format('mm:ss'));
-// console.log(startTime)
 
-
-//   pomodoroInterval = setInterval(() => {
-//     startTime.subtract(1, 'seconds');
-//     timeDisplay.text(startTime.format('mm:ss'));
-//     if (startTime.format('mm:ss') === '00:00') {
-//         clearInterval(pomodoroInterval);
-//     }
-//   }, 1000);
-// });
 
 
 

--- a/assets/js/activity-display.js
+++ b/assets/js/activity-display.js
@@ -8,15 +8,21 @@ $("#startPomodoroTimer").on("click", function(evt){
   var interval = 1000;
   var pomodoroInterval;
 
+  if (workMinutes >= 60) {
+    duration = moment.duration(workMinutes, 'minutes').asHours();
+    duration = moment.duration(duration, 'hours');
+  }
+
   pomodoroInterval = setInterval(function(){
     duration = moment.duration(duration.asMilliseconds() - interval, 'milliseconds');
       if (duration.asMilliseconds() < 0) {
         clearInterval(pomodoroInterval);
         // timeDisplay.innerHTML = "Time's up!";
       } else {
+        var hours = duration.hours();
         var minutes = duration.minutes();
         var seconds = duration.seconds();
-        timeDisplay.text((minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
+        timeDisplay.text((hours < 10 ? '0' + hours : hours) + ':' + (minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
       }
   }, interval);
 });

--- a/assets/js/activity-display.js
+++ b/assets/js/activity-display.js
@@ -1,4 +1,3 @@
-
 //code block to run timer
 $("#startPomodoroTimer").on("click", function(evt){
   evt.preventDefault();
@@ -6,6 +5,7 @@ $("#startPomodoroTimer").on("click", function(evt){
   var shortBreak = parseInt($("#shortBreak").val());
   var longBreak = parseInt($("#longBreak").val());
   var timeDisplay = $("#countdownTimer");
+  var nextText = $("#whatsNext");
   var workDuration = moment.duration(workMinutes, 'minutes');
   var shortBreakDuration = moment.duration(shortBreak, 'minutes');
   var longBreakDuration = moment.duration(longBreak, 'minutes');
@@ -26,6 +26,7 @@ $("#startPomodoroTimer").on("click", function(evt){
         var minutes = workDuration.minutes();
         var seconds = workDuration.seconds();
         timeDisplay.text((minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
+        nextText.text("Short Break ("+shortBreak+" min)");
       }
   }, interval);
 
@@ -36,7 +37,8 @@ $("#startPomodoroTimer").on("click", function(evt){
       var minutes = workDuration.minutes();
       var seconds = workDuration.seconds();
       timeDisplay.text((hours < 10 ? '0' + hours : hours) + ':' + (minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
-  }
+      nextText.text("Short Break ("+shortBreak+" min)");
+    }
 
   function shortBreakStart(){
     shortBreakInterval = setInterval(function(){
@@ -49,6 +51,7 @@ $("#startPomodoroTimer").on("click", function(evt){
           var minutes = shortBreakDuration.minutes();
           var seconds = shortBreakDuration.seconds();
           timeDisplay.text((minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
+          nextText.text("Work block ("+workMinutes+" min)");
         }
     }, interval);
   }
@@ -63,6 +66,7 @@ $("#startPomodoroTimer").on("click", function(evt){
           var minutes = longBreakDuration.minutes();
           var seconds = longBreakDuration.seconds();
           timeDisplay.text((minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
+          nextText.text("Work block ("+workMinutes+" min)");
         }
     }, interval);
   }

--- a/assets/js/activity-display.js
+++ b/assets/js/activity-display.js
@@ -1,20 +1,23 @@
 //Starter code for pomodoro timer
-var workMinutes = parseInt($("#pomodoroTimer").val())
-var duration = moment.duration(workMinutes * 1000, 'milliseconds');
-var timeDisplay = $("#countdownTimer");
-var interval = 1000;
-var sec = 60;
-var pomodoroInterval;
-//checking that workMinutes value is a number
-console.log(typeof workMinutes);
 
-//Code to set countdown timer
+
+//code block to run timer
 $("#startPomodoroTimer").on("click", function(evt){
   evt.preventDefault();
+  var workMinutes = parseInt($("#pomodoroTimer").val())
+  var timeDisplay = $("#countdownTimer");
+  var duration = moment.duration(workMinutes, 'minutes');
+  var interval = 1000;
+  var pomodoroInterval;
   pomodoroInterval = setInterval(function(){
     duration = moment.duration(duration.asMilliseconds() - interval, 'milliseconds');
-    //show how many hours, minutes and seconds are left
-    timeDisplay.text(moment(duration.asMilliseconds()).format('mm:ss'));
+    
+    if (duration.asMilliseconds() < 0) {
+      clearInterval(pomodoroInterval);
+      // timeDisplay.innerHTML = "Time's up!";
+    } else {
+      timeDisplay.text(duration.minutes() + ':' + duration.seconds());
+    }
   }, interval);
 });
 

--- a/assets/js/activity-display.js
+++ b/assets/js/activity-display.js
@@ -1,27 +1,44 @@
-//Starter code for pomodoro timer 
-var userWorkTime = $("#pomodoroTimer").val();
-
-
-
+//Starter code for pomodoro timer
+var workMinutes = parseInt($("#pomodoroTimer").val())
+var duration = moment.duration(workMinutes * 1000, 'milliseconds');
 var timeDisplay = $("#countdownTimer");
-startTime = moment(userWorkTime+':00', 'mm:ss');
-
+var interval = 1000;
+var sec = 60;
 var pomodoroInterval;
+//checking that workMinutes value is a number
+console.log(typeof workMinutes);
+
 //Code to set countdown timer
 $("#startPomodoroTimer").on("click", function(evt){
   evt.preventDefault();
-  console.log(startTime.format('mm:ss'));
-console.log(startTime)
-
-
-  pomodoroInterval = setInterval(() => {
-    startTime.subtract(1, 'seconds');
-    timeDisplay.text(startTime.format('mm:ss'));
-    if (startTime.format('mm:ss') === '00:00') {
-        clearInterval(pomodoroInterval);
-    }
-  }, 1000);
+  pomodoroInterval = setInterval(function(){
+    duration = moment.duration(duration.asMilliseconds() - interval, 'milliseconds');
+    //show how many hours, minutes and seconds are left
+    timeDisplay.text(moment(duration.asMilliseconds()).format('mm:ss'));
+  }, interval);
 });
+
+
+
+// var pomodoroInterval;
+// $("#startPomodoroTimer").on("click", function(evt){
+//   evt.preventDefault();
+//   console.log(startTime.format('mm:ss'));
+// console.log(startTime)
+
+
+//   pomodoroInterval = setInterval(() => {
+//     startTime.subtract(1, 'seconds');
+//     timeDisplay.text(startTime.format('mm:ss'));
+//     if (startTime.format('mm:ss') === '00:00') {
+//         clearInterval(pomodoroInterval);
+//     }
+//   }, 1000);
+// });
+
+
+
+
 
 
 

--- a/assets/js/activity-display.js
+++ b/assets/js/activity-display.js
@@ -1,5 +1,3 @@
-//Starter code for pomodoro timer
-
 
 //code block to run timer
 $("#startPomodoroTimer").on("click", function(evt){
@@ -9,15 +7,17 @@ $("#startPomodoroTimer").on("click", function(evt){
   var duration = moment.duration(workMinutes, 'minutes');
   var interval = 1000;
   var pomodoroInterval;
+
   pomodoroInterval = setInterval(function(){
     duration = moment.duration(duration.asMilliseconds() - interval, 'milliseconds');
-    
-    if (duration.asMilliseconds() < 0) {
-      clearInterval(pomodoroInterval);
-      // timeDisplay.innerHTML = "Time's up!";
-    } else {
-      timeDisplay.text(duration.minutes() + ':' + duration.seconds());
-    }
+      if (duration.asMilliseconds() < 0) {
+        clearInterval(pomodoroInterval);
+        // timeDisplay.innerHTML = "Time's up!";
+      } else {
+        var minutes = duration.minutes();
+        var seconds = duration.seconds();
+        timeDisplay.text((minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
+      }
   }, interval);
 });
 

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
                     <p id="countdownTimer" class="pl-0 py-0 px-0 my-0 mx-0">25:49</p>
                     <div id="additionalTimerInfo" class="text-center px-0">
                         <p class="d-inline">Next: </p>
-                        <p class="d-inline">Short Break (15 minutes)</p>
+                        <p id="whatsNext" class="d-inline">Short Break</p>
                     </div>
 
                 </div>

--- a/index.html
+++ b/index.html
@@ -56,12 +56,12 @@
                                 </div>
                                 <div class="col-4">
                                     <label class="mb-1 form-label inputLabel">Short Break</label>
-                                    <input type="number" placeholder="5" class="form-control col-12">
+                                    <input id="shortBreak" type="number" placeholder="5" class="form-control col-12">
 
                                 </div>
                                 <div class="col-4">
                                     <label class="mb-1 form-label inputLabel">Long Break</label>
-                                    <input type="number" placeholder="15" class="form-control col-12">
+                                    <input id="longBreak" type="number" placeholder="15" class="form-control col-12">
 
                                 </div>
                             </div>


### PR DESCRIPTION
I created a code structure to make the main timer display in the centre and start running when a user enters a pomodoro block, a short break, and a long break.

If the user enters a work block that's longer than 60 minutes, the timer expands to include the HH:MM:SS format.

I've also added a text that's appended dynamically under the timer to notify the user what's coming next.

I'm requesting to merge this with the main branch so that we can look at the functionality so far together. 

HOWEVER, still outstanding tasks are:
- wrap time block code in functions to add logic for running pomodoro blocks 4 times before starting a long break;
- write logic for auto start work and break time blocks
- write logic to start music automatically when timer is starting (?)
- prevent user from not inputting a value at all before starting the timer

@JayaPK21 or @dodzikojo please review and if happy, then please merge