### PR TITLE
52 timer bug fix

### DIFF
--- a/assets/js/timer-logic.js
+++ b/assets/js/timer-logic.js
@@ -1,105 +1,176 @@
-//A variable to set count to how many times pomodoro and break functions run
-var count = 0;
+// //A variable to set count to how many times pomodoro and break functions run
+// var count = 0;
 
-//code block to run timer
+// //code block to run timer
+// $("#startPomodoroTimer").on("click", function(evt){
+//   evt.preventDefault();
+  
+// //variables added inside the on click function, because otherwise user values display as NaN in the timer
+//   var timeDisplay = $("#countdownTimer");
+//   var nextText = $("#whatsNext");
+//   var workMinutes = $("#pomodoroTimer").val();
+//   var shortBreak = $("#shortBreak").val();
+//   var longBreak = $("#longBreak").val();
+  
+// // Check if the user values are null, and if so, set them to the default value
+//   if (workMinutes === '') {
+//     workMinutes = 25;
+//   } else {
+//     workMinutes = parseInt(workMinutes);
+//   }
+
+//   if (shortBreak === '') {
+//     shortBreak = 5;
+//   } else {
+//     shortBreak = parseInt(shortBreak);
+//   }
+
+//   if (longBreak === '') {
+//     longBreak = 15;
+//   } else {
+//     longBreak = parseInt(longBreak);
+//   }
+
+
+// //moment.duration methods for the timer
+//   var workDuration = moment.duration(workMinutes, 'minutes');
+//   var shortBreakDuration = moment.duration(shortBreak, 'minutes');
+//   var longBreakDuration = moment.duration(longBreak, 'minutes');
+//   var interval = 1000;
+//   var pomodoroInterval;
+
+
+// //function to display Time in the main block
+//   function displayTime(duration, text) {
+//     var minutes = duration.minutes();
+//     var seconds = duration.seconds();
+//     if (seconds < 0) {
+//       seconds = 0;
+//     }
+//     timeDisplay.text((minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
+//     nextText.text(text);
+//   }
+  
+// //function to start pomodoros
+//   function startPomodoroInterval(){
+// //re-setting workDuration so it starts from the original user input value again
+//   workDuration = moment.duration(workMinutes, 'minutes');
+//   pomodoroInterval = setInterval(function(){
+//     workDuration = moment.duration(workDuration.asMilliseconds() - interval, 'milliseconds');
+//     if (workDuration.asMilliseconds() < 0) {
+//       clearInterval(pomodoroInterval);
+//       count++;
+//       if (count < 3){
+//         shortBreakStart();
+//         displayTime(workDuration, "Short Break ("+shortBreak+" min)");
+//         } else if (count === 3) {
+//           longBreakStart();
+//           displayTime(workDuration, "Long Break ("+longBreak+" min)");
+//         }
+//     // } else {
+//     //   displayTime(workDuration);
+//     }
+//   }, interval);
+//   }
+  
+//   startPomodoroInterval();
+
+//   function shortBreakStart(){
+//     shortBreakDuration = moment.duration(shortBreak, 'minutes');
+//     shortBreakInterval = setInterval(function(){
+//       shortBreakDuration = moment.duration(shortBreakDuration.asMilliseconds() - interval, 'milliseconds');
+//       if (shortBreakDuration.asMilliseconds() < 0) {
+//         clearInterval(shortBreakInterval);
+//         startPomodoroInterval();
+//         } else {
+//           displayTime(shortBreakDuration, "Work block ("+workMinutes+" min)");
+//         }
+//     }, interval);
+//   }
+
+//   function longBreakStart(){
+//     longBreakDuration = moment.duration(longBreak, 'minutes');
+//     longBreakInterval = setInterval(function(){
+//       longBreakDuration = moment.duration(longBreakDuration.asMilliseconds() - interval, 'milliseconds');
+//       count = 0;
+//       if (longBreakDuration.asMilliseconds() < 0) {
+//         clearInterval(longBreakInterval);
+//         startPomodoroInterval();
+//       } else {
+//         displayTime(longBreakDuration, "Work block ("+workMinutes+" min)");
+//       }
+//     }, interval);
+//   }
+
+
+// });
+
+var count = 0;
+var workDuration, shortBreakDuration, longBreakDuration, interval, pomodoroInterval;
+var timeDisplay = $("#countdownTimer");
+var nextText = $("#whatsNext");
+
 $("#startPomodoroTimer").on("click", function(evt){
   evt.preventDefault();
   
-//variables added inside the on click function, because otherwise user values display as NaN in the timer
-  var timeDisplay = $("#countdownTimer");
-  var nextText = $("#whatsNext");
-  var workMinutes = $("#pomodoroTimer").val();
-  var shortBreak = $("#shortBreak").val();
-  var longBreak = $("#longBreak").val();
+  var workMinutes = $("#pomodoroTimer").val() || 25;
+  var shortBreak = $("#shortBreak").val() || 5;
+  var longBreak = $("#longBreak").val() || 15;
+
+  workDuration = moment.duration(workMinutes, 'minutes');
+  shortBreakDuration = moment.duration(shortBreak, 'minutes');
+  longBreakDuration = moment.duration(longBreak, 'minutes');
+  interval = 1000;
   
-// Check if the user values are null, and if so, set them to the default value
-  if (workMinutes === '') {
-    workMinutes = 25;
-  } else {
-    workMinutes = parseInt(workMinutes);
-  }
-
-  if (shortBreak === '') {
-    shortBreak = 5;
-  } else {
-    shortBreak = parseInt(shortBreak);
-  }
-
-  if (longBreak === '') {
-    longBreak = 15;
-  } else {
-    longBreak = parseInt(longBreak);
-  }
-
-
-//moment.duration methods for the timer
-  var workDuration = moment.duration(workMinutes, 'minutes');
-  var shortBreakDuration = moment.duration(shortBreak, 'minutes');
-  var longBreakDuration = moment.duration(longBreak, 'minutes');
-  var interval = 1000;
-  var pomodoroInterval;
-
-
-//function to display Time in the main block
   function displayTime(duration, text) {
     var minutes = duration.minutes();
     var seconds = duration.seconds();
+    if (seconds < 0) {
+      seconds = 0;
+    }
     timeDisplay.text((minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
     nextText.text(text);
   }
   
-//function to start pomodoros
   function startPomodoroInterval(){
-//re-setting workDuration so it starts from the original user input value again
-  workDuration = moment.duration(workMinutes, 'minutes');
-  pomodoroInterval = setInterval(function(){
-    workDuration = moment.duration(workDuration.asMilliseconds() - interval, 'milliseconds');
-    if (workDuration.asMilliseconds() < 0) {
-      clearInterval(pomodoroInterval);
-      count++;
-      if (count < 3) {
-        displayTime(shortBreakDuration, "Work block ("+workMinutes+" min)");
-      } else if (count === 3) {
-        displayTime(longBreakDuration, "Work block ("+workMinutes+" min)");
-      }      
-    } else {
-      displayTime(workDuration, "Short Break ("+shortBreak+" min)");
-    }
-  }, interval);
+    workDuration = moment.duration(workMinutes, 'minutes');
+    pomodoroInterval = setInterval(function(){
+      workDuration = moment.duration(workDuration.asMilliseconds() - interval, 'milliseconds');
+      displayTime(workDuration, "Work block ("+workMinutes+" min)");
+      if (workDuration.asMilliseconds() < 0) {
+        clearInterval(pomodoroInterval);
+        count++;
+        if (count < 3){
+          shortBreakStart();
+        } else if (count === 3) {
+          longBreakStart();
+        }
+      }
+    }, interval);
   }
-  startPomodoroInterval();
-//took if statements containing function calls out of the main pomodoroInterval function
-  if (count < 3){
-    shortBreakStart();
-    } else if (count === 3) {
-      longBreakStart();
-    }      
-
+  
   function shortBreakStart(){
-    shortBreakDuration = moment.duration(shortBreak, 'minutes');
     shortBreakInterval = setInterval(function(){
       shortBreakDuration = moment.duration(shortBreakDuration.asMilliseconds() - interval, 'milliseconds');
+      displayTime(shortBreakDuration, "Short Break ("+shortBreak+" min)");
       if (shortBreakDuration.asMilliseconds() < 0) {
         clearInterval(shortBreakInterval);
         startPomodoroInterval();
-        } else {
-          displayTime(shortBreakDuration, "Work block ("+workMinutes+" min)");
-        }
+        } 
     }, interval);
   }
 
   function longBreakStart(){
-    longBreakDuration = moment.duration(longBreak, 'minutes');
     longBreakInterval = setInterval(function(){
       longBreakDuration = moment.duration(longBreakDuration.asMilliseconds() - interval, 'milliseconds');
+      displayTime(longBreakDuration, "Long Break ("+longBreak+" min)");
       if (longBreakDuration.asMilliseconds() < 0) {
         clearInterval(longBreakInterval);
+        count = 0;
         startPomodoroInterval();
-      } else {
-        displayTime(longBreakDuration, "Work block ("+workMinutes+" min)");
-      }
+      } 
     }, interval);
   }
 
-
+  startPomodoroInterval();
 });

--- a/assets/js/timer-logic.js
+++ b/assets/js/timer-logic.js
@@ -56,9 +56,14 @@ $("#startPomodoroTimer").on("click", function(evt){
     workDuration = moment.duration(workDuration.asMilliseconds() - interval, 'milliseconds');
     if (workDuration.asMilliseconds() < 0) {
       clearInterval(pomodoroInterval);
-      console.log('shortBreakStart function called');
-      shortBreakStart();
-      
+      count++;
+      if (count < 4) {
+        shortBreakStart();
+        displayTime(shortBreakDuration, "Work block ("+workMinutes+" min)");
+      } else if (count === 4) {
+        longBreakStart();
+        displayTime(longBreakDuration, "Work block ("+workMinutes+" min)");
+      }      
     } else {
       displayTime(workDuration, "Short Break ("+shortBreak+" min)");
     }
@@ -72,16 +77,10 @@ $("#startPomodoroTimer").on("click", function(evt){
       shortBreakDuration = moment.duration(shortBreakDuration.asMilliseconds() - interval, 'milliseconds');
       if (shortBreakDuration.asMilliseconds() < 0) {
         clearInterval(shortBreakInterval);
-        count++;
-        if (count < 4) {
-          startPomodoroInterval();
+        startPomodoroInterval();
         } else {
-          longBreakStart();
           displayTime(shortBreakDuration, "Work block ("+workMinutes+" min)");
         }
-      } else {
-        displayTime(shortBreakDuration, "Work block ("+workMinutes+" min)");
-      }
     }, interval);
   }
 

--- a/assets/js/timer-logic.js
+++ b/assets/js/timer-logic.js
@@ -57,19 +57,30 @@ $("#startPomodoroTimer").on("click", function(evt){
     if (workDuration.asMilliseconds() < 0) {
       clearInterval(pomodoroInterval);
       count++;
-      if (count < 4) {
-        shortBreakStart();
-        displayTime(shortBreakDuration, "Work block ("+workMinutes+" min)");
-      } else if (count === 4) {
-        longBreakStart();
-        displayTime(longBreakDuration, "Work block ("+workMinutes+" min)");
-      }      
-    } else {
-      displayTime(workDuration, "Short Break ("+shortBreak+" min)");
+    //   if (count < 3) {
+    //     shortBreakStart();
+    //     displayTime(shortBreakDuration, "Work block ("+workMinutes+" min)");
+    //   } else if (count === 3) {
+    //     longBreakStart();
+    //     displayTime(longBreakDuration, "Work block ("+workMinutes+" min)");
+    //   }      
+    // } else {
+    //   displayTime(workDuration, "Short Break ("+shortBreak+" min)");
     }
   }, interval);
   }
   startPomodoroInterval();
+
+  if (count < 3) {
+    shortBreakStart();
+    displayTime(shortBreakDuration, "Work block ("+workMinutes+" min)");
+  } else if (count === 3) {
+    longBreakStart();
+    displayTime(longBreakDuration, "Work block ("+workMinutes+" min)");
+  }      
+} else {
+  displayTime(workDuration, "Short Break ("+shortBreak+" min)");
+
 
   function shortBreakStart(){
     shortBreakDuration = moment.duration(shortBreak, 'minutes');
@@ -96,4 +107,6 @@ $("#startPomodoroTimer").on("click", function(evt){
       }
     }, interval);
   }
+
+
 });

--- a/assets/js/timer-logic.js
+++ b/assets/js/timer-logic.js
@@ -57,30 +57,23 @@ $("#startPomodoroTimer").on("click", function(evt){
     if (workDuration.asMilliseconds() < 0) {
       clearInterval(pomodoroInterval);
       count++;
-    //   if (count < 3) {
-    //     shortBreakStart();
-    //     displayTime(shortBreakDuration, "Work block ("+workMinutes+" min)");
-    //   } else if (count === 3) {
-    //     longBreakStart();
-    //     displayTime(longBreakDuration, "Work block ("+workMinutes+" min)");
-    //   }      
-    // } else {
-    //   displayTime(workDuration, "Short Break ("+shortBreak+" min)");
+      if (count < 3) {
+        displayTime(shortBreakDuration, "Work block ("+workMinutes+" min)");
+      } else if (count === 3) {
+        displayTime(longBreakDuration, "Work block ("+workMinutes+" min)");
+      }      
+    } else {
+      displayTime(workDuration, "Short Break ("+shortBreak+" min)");
     }
   }, interval);
   }
   startPomodoroInterval();
-
-  if (count < 3) {
+//took if statements containing function calls out of the main pomodoroInterval function
+  if (count < 3){
     shortBreakStart();
-    displayTime(shortBreakDuration, "Work block ("+workMinutes+" min)");
-  } else if (count === 3) {
-    longBreakStart();
-    displayTime(longBreakDuration, "Work block ("+workMinutes+" min)");
-  }      
-} else {
-  displayTime(workDuration, "Short Break ("+shortBreak+" min)");
-
+    } else if (count === 3) {
+      longBreakStart();
+    }      
 
   function shortBreakStart(){
     shortBreakDuration = moment.duration(shortBreak, 'minutes');

--- a/assets/js/timer-logic.js
+++ b/assets/js/timer-logic.js
@@ -31,7 +31,6 @@ $("#startPomodoroTimer").on("click", function(evt){
     pomodoroInterval = setInterval(function(){
       workDuration = moment.duration(workDuration.asMilliseconds() - interval, 'milliseconds');
       displayTime(workDuration, "Work block ("+workMinutes+" min)"); 
-      // A counter and if statements to clear interval when it reaches 0 and to display long break after 4 pomodoros
       if (workDuration.asMilliseconds() < 0) {
         clearInterval(pomodoroInterval);
         countIntervals++
@@ -42,7 +41,6 @@ $("#startPomodoroTimer").on("click", function(evt){
           longBreakStart();
         }
       }
-
     }, interval);
   }
 //short break

--- a/assets/js/timer-logic.js
+++ b/assets/js/timer-logic.js
@@ -1,127 +1,21 @@
-// //A variable to set count to how many times pomodoro and break functions run
-// var count = 0;
-
-// //code block to run timer
-// $("#startPomodoroTimer").on("click", function(evt){
-//   evt.preventDefault();
-  
-// //variables added inside the on click function, because otherwise user values display as NaN in the timer
-//   var timeDisplay = $("#countdownTimer");
-//   var nextText = $("#whatsNext");
-//   var workMinutes = $("#pomodoroTimer").val();
-//   var shortBreak = $("#shortBreak").val();
-//   var longBreak = $("#longBreak").val();
-  
-// // Check if the user values are null, and if so, set them to the default value
-//   if (workMinutes === '') {
-//     workMinutes = 25;
-//   } else {
-//     workMinutes = parseInt(workMinutes);
-//   }
-
-//   if (shortBreak === '') {
-//     shortBreak = 5;
-//   } else {
-//     shortBreak = parseInt(shortBreak);
-//   }
-
-//   if (longBreak === '') {
-//     longBreak = 15;
-//   } else {
-//     longBreak = parseInt(longBreak);
-//   }
-
-
-// //moment.duration methods for the timer
-//   var workDuration = moment.duration(workMinutes, 'minutes');
-//   var shortBreakDuration = moment.duration(shortBreak, 'minutes');
-//   var longBreakDuration = moment.duration(longBreak, 'minutes');
-//   var interval = 1000;
-//   var pomodoroInterval;
-
-
-// //function to display Time in the main block
-//   function displayTime(duration, text) {
-//     var minutes = duration.minutes();
-//     var seconds = duration.seconds();
-//     if (seconds < 0) {
-//       seconds = 0;
-//     }
-//     timeDisplay.text((minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
-//     nextText.text(text);
-//   }
-  
-// //function to start pomodoros
-//   function startPomodoroInterval(){
-// //re-setting workDuration so it starts from the original user input value again
-//   workDuration = moment.duration(workMinutes, 'minutes');
-//   pomodoroInterval = setInterval(function(){
-//     workDuration = moment.duration(workDuration.asMilliseconds() - interval, 'milliseconds');
-//     if (workDuration.asMilliseconds() < 0) {
-//       clearInterval(pomodoroInterval);
-//       count++;
-//       if (count < 3){
-//         shortBreakStart();
-//         displayTime(workDuration, "Short Break ("+shortBreak+" min)");
-//         } else if (count === 3) {
-//           longBreakStart();
-//           displayTime(workDuration, "Long Break ("+longBreak+" min)");
-//         }
-//     // } else {
-//     //   displayTime(workDuration);
-//     }
-//   }, interval);
-//   }
-  
-//   startPomodoroInterval();
-
-//   function shortBreakStart(){
-//     shortBreakDuration = moment.duration(shortBreak, 'minutes');
-//     shortBreakInterval = setInterval(function(){
-//       shortBreakDuration = moment.duration(shortBreakDuration.asMilliseconds() - interval, 'milliseconds');
-//       if (shortBreakDuration.asMilliseconds() < 0) {
-//         clearInterval(shortBreakInterval);
-//         startPomodoroInterval();
-//         } else {
-//           displayTime(shortBreakDuration, "Work block ("+workMinutes+" min)");
-//         }
-//     }, interval);
-//   }
-
-//   function longBreakStart(){
-//     longBreakDuration = moment.duration(longBreak, 'minutes');
-//     longBreakInterval = setInterval(function(){
-//       longBreakDuration = moment.duration(longBreakDuration.asMilliseconds() - interval, 'milliseconds');
-//       count = 0;
-//       if (longBreakDuration.asMilliseconds() < 0) {
-//         clearInterval(longBreakInterval);
-//         startPomodoroInterval();
-//       } else {
-//         displayTime(longBreakDuration, "Work block ("+workMinutes+" min)");
-//       }
-//     }, interval);
-//   }
-
-
-// });
-
-var count = 0;
+//set variables
+var countIntervals = 0;
 var workDuration, shortBreakDuration, longBreakDuration, interval, pomodoroInterval;
 var timeDisplay = $("#countdownTimer");
 var nextText = $("#whatsNext");
-
+//onclick to start pomodoro timer
 $("#startPomodoroTimer").on("click", function(evt){
   evt.preventDefault();
-  
+//grabbing user values from input fields, or using default if input is null
   var workMinutes = $("#pomodoroTimer").val() || 25;
   var shortBreak = $("#shortBreak").val() || 5;
   var longBreak = $("#longBreak").val() || 15;
-
+//using moment.duration to set work and break blocks
   workDuration = moment.duration(workMinutes, 'minutes');
   shortBreakDuration = moment.duration(shortBreak, 'minutes');
   longBreakDuration = moment.duration(longBreak, 'minutes');
   interval = 1000;
-  
+//storing time display format in a function that will be called in work and break blocks
   function displayTime(duration, text) {
     var minutes = duration.minutes();
     var seconds = duration.seconds();
@@ -131,42 +25,45 @@ $("#startPomodoroTimer").on("click", function(evt){
     timeDisplay.text((minutes < 10 ? '0' + minutes : minutes) + ':' + (seconds < 10 ? '0' + seconds : seconds));
     nextText.text(text);
   }
-  
+//main Pomodoro
   function startPomodoroInterval(){
     workDuration = moment.duration(workMinutes, 'minutes');
     pomodoroInterval = setInterval(function(){
       workDuration = moment.duration(workDuration.asMilliseconds() - interval, 'milliseconds');
-      displayTime(workDuration, "Work block ("+workMinutes+" min)");
+      displayTime(workDuration, "Work block ("+workMinutes+" min)"); 
+      // A counter and if statements to clear interval when it reaches 0 and to display long break after 4 pomodoros
       if (workDuration.asMilliseconds() < 0) {
         clearInterval(pomodoroInterval);
-        count++;
-        if (count < 3){
+        countIntervals++
+        if (countIntervals < 3){
           shortBreakStart();
-        } else if (count === 3) {
+        } else if (countIntervals === 4) {
           longBreakStart();
         }
       }
+
     }, interval);
   }
-  
+//short break
   function shortBreakStart(){
     shortBreakInterval = setInterval(function(){
       shortBreakDuration = moment.duration(shortBreakDuration.asMilliseconds() - interval, 'milliseconds');
-      displayTime(shortBreakDuration, "Short Break ("+shortBreak+" min)");
+      displayTime(shortBreakDuration, "Short break ("+shortBreak+" min)");
       if (shortBreakDuration.asMilliseconds() < 0) {
         clearInterval(shortBreakInterval);
         startPomodoroInterval();
         } 
     }, interval);
   }
-
+//long break
   function longBreakStart(){
     longBreakInterval = setInterval(function(){
       longBreakDuration = moment.duration(longBreakDuration.asMilliseconds() - interval, 'milliseconds');
-      displayTime(longBreakDuration, "Long Break ("+longBreak+" min)");
+      displayTime(longBreakDuration, "Long break ("+longBreak+" min)");
       if (longBreakDuration.asMilliseconds() < 0) {
         clearInterval(longBreakInterval);
-        count = 0;
+        //resetting pomodoro
+        countIntervals = 0;
         startPomodoroInterval();
       } 
     }, interval);

--- a/assets/js/timer-logic.js
+++ b/assets/js/timer-logic.js
@@ -35,7 +35,8 @@ $("#startPomodoroTimer").on("click", function(evt){
       if (workDuration.asMilliseconds() < 0) {
         clearInterval(pomodoroInterval);
         countIntervals++
-        if (countIntervals < 3){
+        console.log("Pomodoro nr "+ countIntervals);
+        if (countIntervals < 4){
           shortBreakStart();
         } else if (countIntervals === 4) {
           longBreakStart();
@@ -46,6 +47,8 @@ $("#startPomodoroTimer").on("click", function(evt){
   }
 //short break
   function shortBreakStart(){
+    shortBreakDuration = moment.duration(shortBreak, 'minutes');
+    console.log ("short break")
     shortBreakInterval = setInterval(function(){
       shortBreakDuration = moment.duration(shortBreakDuration.asMilliseconds() - interval, 'milliseconds');
       displayTime(shortBreakDuration, "Short break ("+shortBreak+" min)");
@@ -57,6 +60,8 @@ $("#startPomodoroTimer").on("click", function(evt){
   }
 //long break
   function longBreakStart(){
+    longBreakDuration = moment.duration(longBreak, 'minutes');
+    console.log("long break")
     longBreakInterval = setInterval(function(){
       longBreakDuration = moment.duration(longBreakDuration.asMilliseconds() - interval, 'milliseconds');
       displayTime(longBreakDuration, "Long break ("+longBreak+" min)");

--- a/assets/js/todos-logic.js
+++ b/assets/js/todos-logic.js
@@ -1,4 +1,4 @@
-
+//this isn't finished yet, there's an open branch for this still
 //Code for the appendable 'to do' list
 var todoInput = $("#todo-text");
 var todoForm = $("#todo-form");

--- a/assets/js/todos-logic.js
+++ b/assets/js/todos-logic.js
@@ -1,17 +1,15 @@
 
-// // COMMENTED OUT CODE BELOW AS PLACEHOLDER FOR TO-DO LIST GENERATION
-// //_________________________________________________________________
-// //Code for the appendable 'to do' list
-// var todoInput = $("#todo-text");
-// var todoForm = $("#todo-form");
-// var todoList = $("#todo-list");
-// var todoCountSpan = $("#todo-count");
-// //an empty array to store todos
-// var todos = [];
-// //A function to store to dos as a string
-// var storeTodos = function() {
-//   localStorage.setItem("todos", JSON.stringify(todos));
-// }
+//Code for the appendable 'to do' list
+var todoInput = $("#todo-text");
+var todoForm = $("#todo-form");
+var todoList = $("#todo-list");
+var todoCountSpan = $("#todo-count");
+//an empty array to store todos
+var todos = [];
+//A function to store to dos as a string
+var storeTodos = function() {
+  localStorage.setItem("todos", JSON.stringify(todos));
+}
 
 // function renderTodos() {
 //   // Clear todoList element and update todoCountSpan

--- a/index.html
+++ b/index.html
@@ -218,8 +218,8 @@
                     class="text-center shadow-lg position-absolute top-50 start-50 translate-middle">
                     <p id="countdownTimer" class="pl-0 py-0 px-0 my-0 mx-0">25:00</p>
                     <div id="additionalTimerInfo" class="text-center px-0">
-                        <p class="d-inline">Current: </p>
-                        <p id="whatsNext" class="d-inline">Work Block</p>
+                        <p class="d-inline">Running: </p>
+                        <p id="whatsNext" class="d-inline">Work timer</p>
                     </div>
 
                 </div>

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
                                 <div class="col-4">
                                     <label class="mb-1 form-label inputLabel">Long Break</label>
                                     <input id="longBreak" type="number" min="5" max="60" placeholder="15" class="form-control col-12">
+                                </div>
                             </div>
                         </div>
                         <div class="col-12 mt-3">

--- a/index.html
+++ b/index.html
@@ -218,8 +218,8 @@
                     class="text-center shadow-lg position-absolute top-50 start-50 translate-middle">
                     <p id="countdownTimer" class="pl-0 py-0 px-0 my-0 mx-0">25:00</p>
                     <div id="additionalTimerInfo" class="text-center px-0">
-                        <p class="d-inline">Next: </p>
-                        <p id="whatsNext" class="d-inline">Short Break</p>
+                        <p class="d-inline">Current: </p>
+                        <p id="whatsNext" class="d-inline">Work Block</p>
                     </div>
 
                 </div>

--- a/index.html
+++ b/index.html
@@ -48,12 +48,6 @@
                                 <div class="col-4">
                                     <label class="mb-1 form-label inputLabel">Long Break</label>
                                     <input id="longBreak" type="number" min="5" max="60" placeholder="15" class="form-control col-12">
-
-                                </div>
-                                <div class="col-4">
-                                    <label class="mb-1 form-label inputLabel">Long Break</label>
-                                    <input id="longBreak" type="number" placeholder="15" class="form-control col-12">
-                                </div>
                             </div>
                         </div>
                         <div class="col-12 mt-3">
@@ -221,7 +215,7 @@
 
                 <div id="countdownTimerContainer"
                     class="text-center shadow-lg position-absolute top-50 start-50 translate-middle">
-                    <p id="countdownTimer" class="pl-0 py-0 px-0 my-0 mx-0">25:49</p>
+                    <p id="countdownTimer" class="pl-0 py-0 px-0 my-0 mx-0">25:00</p>
                     <div id="additionalTimerInfo" class="text-center px-0">
                         <p class="d-inline">Next: </p>
                         <p id="whatsNext" class="d-inline">Short Break</p>


### PR DESCRIPTION
The timer now runs consequetively, and can be tested by setting all time blocks as 1 minute and checking the console log (all pomodoros should console log like this:
pomodoro 1
short break
pomodoro2
short break
pomodoro3
short break
pomodoro4
long break

And then re-starting from pomodoro 1 again.

I was unable to figure out the logic to display 'what's next' below the timer (e.g. Next: short break (3 min)), so instead the timer now displays what's currently running (e.g. Running: work timer (5 min)). This bit is quite tricky, so I suggest leaving the code as is, and maybe coming back to add the logic to display 'what's next' if we have time.
